### PR TITLE
Separated camera functionality to PlayerCamera.cs

### DIFF
--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -23,7 +23,8 @@ public class Player : MonoBehaviour
     private float invulnTime = 2;
     private CharacterController controller;
     private Animator anim; 
-    public Camera camera;
+    // Moved camera functionality to PlayerCamera.cs
+    // public Camera camera;
     private GameObject holdItem;
 
     // Start is called before the first frame update
@@ -59,7 +60,8 @@ public class Player : MonoBehaviour
             }
             this.transform.LookAt(transform.position + dir); // look in direction that player is walking
             controller.SimpleMove(this.moveSpeed * dir);
-            camera.transform.position = new Vector3(this.transform.position.x, 21.5f, this.transform.position.z - 10);
+            // Moved camera functionality to PlayerCamera.cs
+            // camera.transform.position = new Vector3(this.transform.position.x, 21.5f, this.transform.position.z - 10);
         }
         else if (dir.sqrMagnitude == 0){
             if(this.holdItem){

--- a/Assets/Scripts/PlayerCamera.cs
+++ b/Assets/Scripts/PlayerCamera.cs
@@ -1,0 +1,19 @@
+﻿// Controls the movement of the Camera that follows the Player.
+// Referenced https://code.tutsplus.com/tutorials/unity3d-third-person-cameras--mobile-11230
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerCamera : MonoBehaviour
+{
+    public GameObject target;
+    Vector3 offset = new Vector3(0, 19f, -10);
+
+    // Update is called once per frame
+    void LateUpdate()
+    {
+        Vector3 desiredPosition = target.transform.position + offset;
+        transform.position = desiredPosition;
+    }
+}

--- a/Assets/Scripts/PlayerCamera.cs.meta
+++ b/Assets/Scripts/PlayerCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 933f06dc033614e4cacdcfac177b00b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Figured it'd be better to have the camera script separate from the
Player script. As a side benefit, this squelches the warning
"Player.camera hides inherited member Component.camera"