### PR TITLE
Build 0.73.1 changes

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -4308,7 +4308,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1299843946}
-        m_MethodName: ShowPlayOptions
+        m_MethodName: StartGame
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/game.unity
+++ b/Assets/Scenes/game.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -16262,7 +16262,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &635318016
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Ape Ship Version 0.73.1 Release Notes
 - Temporarily disabled the player position on the minimap
 - The Play button on the main menu now launches the game in single-player.

Known Issues
 - There is currently no UI of the Endgame transition period of the game.
    - When the progress bar reaches the end, players must step into the teleporter pad.
 - The Electrical minigame only requires 1-2 mirrors to solve the minigame, yet has all 4 still in.